### PR TITLE
Onboarding Fresher Handbook Updates

### DIFF
--- a/engineering/onboarding-fresher.md
+++ b/engineering/onboarding-fresher.md
@@ -1,6 +1,6 @@
 # Onboarding Freshers
 
-At JTC, we primarily work with enterprises to build solutions that help them to achieve business efficiencies and scale their business. For a large part, the solutions we deliver are based on web technologies. As of writing this document, our choice of stack is **Typescript, Node, React**.
+At Jalan Technologies, we primarily work with enterprises to build solutions that help them to achieve business efficiencies and scale their business. For a large part, the solutions we deliver are based on web technologies. As of writing this document, our choice of stack is **Typescript, Node, React**.
 
 This document assumes that you have no or minimal experience with this stack of professional software development in general. However, it assumes that you are proactive, independent and have strong problem solving skills to be able to figure out things on your own. If you do, we hope that you should be able to move through this quickly.
 
@@ -12,7 +12,7 @@ In order to help you learn MERN stack related technology, we rely on [Odin proje
 
 Curriculum Link: [https://www.theodinproject.com/paths/foundations/courses/foundations](https://www.theodinproject.com/paths/foundations/courses/foundations)
 
-Expected time to finish: ~2 weeks\*
+Expected time to finish: ~1 week\*
 
 ### 2. Full stack development using Javascript
 
@@ -20,14 +20,17 @@ Curriculum Link: [https://www.theodinproject.com/paths/full-stack-javascript](ht
 
 Expected time to finish:
 
--   Javascript: 1.5 weeks\*
--   React: 2.5 weeks\*
--   Node: 3.5 weeks\*
+- Javascript: 1.5 weeks\*
+
+- React: 2.5 weeks\*
+
+- Node: 2.5 weeks\*
 
 NOTE:
 
--   Reminder: Please do not rush through or keep things for last minute or finish just for the sake of finishing. This is an opportunity for you to build YOUR skills. If you do not give 100%, we have seen over and over that such engineers do not end up performing well when they work on a real product with us.
--   \*The above timeline assumes you are putting in at least 8 hours a day, 5 days a week.
+- Reminder: Please do not rush through or keep things for last minute or finish just for the sake of finishing. This is an opportunity for you to build YOUR skills. If you do not give 100%, we have seen over and over that such engineers do not end up performing well when they work on a real product with us.
+
+- \*The above timeline assumes you are putting in at least 8 hours a day, 5 days a week.
 
 ## Logistics
 
@@ -35,41 +38,84 @@ NOTE:
 
 At the time of joining, you will be assigned a mentor who will be your single point of contact on Engineering as you go through the onboarding. If you have not been assigned a mentor, please reach out to HR to ask for your mentor.
 
+### Key Skills for Team Member Success:
+
+At Jalan Technologies, our mentorship program includes regular check-ins between mentors and mentees to review code and assess progress. These evaluations allow us to identify and focus on developing the following key skills and abilities among our team members.
+
+1.  Avoiding repetition of mistakes: While mistakes are a natural part of the learning process, we value individuals who can take feedback, learn from their mistakes and apply that knowledge to prevent repetition.
+    
+
+2.  Learning aptitude: We look for individuals who have the ability to learn new concepts and technologies in-depth, and apply their knowledge to create high-quality solutions. Strong fundamentals are a plus.
+    
+
+3.  Problem-solving: We value team members who can find solutions to their problems independently, particularly with regard to out-of-the-box technologies.
+    
+
+4.  Code quality: As an engineering company, we prioritize craftsmanship in code writing and look for individuals who have a strong understanding of object-oriented programming principles.
+    
+
+5.  Communication: Effective communication is essential in the workplace. We place a high value on team members who can clearly and concisely convey their thoughts and ideas.
+    
+
+6.  Commitment: We look for individuals who can be relied upon to deliver on their commitments and support the team and customers alike.
+
 ### Daily Standup:
 
 Every day, please send your daily status update to `Onboarding (Engineering)` channel. Here is a sample format of daily status update:
 
 ```
+
 Progress:
+
 -------------
-- Read JTC development process
+
+- Read Jalan Technologies development process
+
 - Completed day 1 eng-onboarding exercise
 
 Plan:
+
 -------------
+
 - Start on understanding Node boilerplate
+
 - Start on building TODO application repo
 
 Problems:
+
 -------------
+
 - None
+
 ```
-
-### Demo Day:
-
-Every two weeks, there will be a demo day where you will be asked to present all the projects you completed as part of curriculum. The objective of this demo day is for fresher to showcase their projects (max ~5 minutes each) and mentors to evaluate the progress.
+    
 
 ### Github handle for work
 
 There are two options:
 
-1. Use personal Github handle (**recommended**): Add your JTC work email as [secondary email to your Github](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/adding-an-email-address-to-your-github-account) handle.
+1. Use personal Github handle (**recommended**): Add your Jalan Technologies work email as [secondary email to your Github](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/adding-an-email-address-to-your-github-account) handle.
 
-    ```
-    $ git config --global user.name <YOUR NAME>
-    $ git config --global user.email <YOUR WORK EMAIL>
-    ```
+```
 
-    This way, you build your personal Github profile while doing commit on behalf of the company.
+$ git config --global user.name <YOUR NAME>
 
-2. Create a separate JTC specific Github handle.
+$ git config --global user.email <YOUR WORK EMAIL>
+
+```
+
+This way, you build your personal Github profile while doing commit on behalf of the company.
+
+2. Create a separate Jalan Technologies specific Github handle.
+
+###  Setup IDE
+
+  
+
+Every team member has their preference but we generally use VSCode. Please also install a [prettier plugin](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) to make sure the code you write in any project is well formatted.
+
+###  Raise a PR
+
+  
+
+We encourage you to raise your PR daily once you are done for the day, a PR on Github to merge these changes against the develop branch. Please see raising [pull request etiquette](https://github.com/jalantechnologies/handbook/blob/main/engineering/pr-etiquette.md).


### PR DESCRIPTION
Updated following things:
- The curriculum timeline
- Removed Demo Day and added Key Skills section
- Added IDE Setup and PR Etiquette sections
- Replace JTC and JT with Jalan Technologies