### PR TITLE
Fix internal links in handbook for GitHub Pages compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ Please read [this page](/common/performance_growth.md) to learn about performanc
 
 ## Functional Onboarding
 
--   Software Engineering, start [here](https://github.com/jalantechnologies/handbook/blob/main/engineering/index.md)
--   Product Manager, start [here](https://github.com/jalantechnologies/handbook/blob/main/product-management/index.md)
+-   Software Engineering, start [here](/engineering/index.md)
+-   Product Manager, start [here](/product-management/index.md)

--- a/engineering/index.md
+++ b/engineering/index.md
@@ -18,7 +18,7 @@ Understanding the user base in this scenario can lead to better product developm
 ## Engineering How To:
 - [How to build maintainable frontends that future dev's would thank you for](https://www.loom.com/share/c4352f7c0be949e8bc0377dbcba15daa)
 - [How we think about building backend - Part 1](https://www.loom.com/share/e10b30d5d53c43b5bceea52177737bb0?sid=e42a852a-40fe-4007-964f-facd2a7b61a6)
-- [How to raise a Perfect PR](https://github.com/jalantechnologies/handbook/blob/main/engineering/pr-etiquette.md)
+- [How to raise a Perfect PR](/engineering/pr-etiquette.md)
 - [How to be great at asking coding questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603)
 - [How to write better code comments](https://dev.to/adammc331/todo-write-a-better-comment-4c8c)
 - [How to name your automated tests](https://markus.oberlehner.net/blog/naming-your-unit-tests-it-should-vs-given-when-then/)
@@ -27,5 +27,5 @@ Understanding the user base in this scenario can lead to better product developm
 - [Three Git Configurations that Should Be the Default](https://spin.atomicobject.com/git-configurations-default)
 
 ## Getting Started:
-- Fresher: [Start here](https://github.com/jalantechnologies/handbook/blob/main/engineering/onboarding-fresher.md)
-- [Lead Roles & Responsibilities](https://github.com/jalantechnologies/handbook/blob/main/engineering/lead.md)
+- Fresher: [Start here](/engineering/onboarding-fresher.md)
+- [Lead Roles & Responsibilities](/engineering/lead.md)

--- a/engineering/lead.md
+++ b/engineering/lead.md
@@ -2,7 +2,7 @@
 
 At some point in your career at Better, you will be asked to take up an engineering lead role, even when you are sometime not ready, in the product you are working. As a lead, you are responsible to:
 
--   Work with product manager to create technical architecture based on the PRD document (ref: [PM Handbook](https://github.com/jalantechnologies/handbook/blob/main/product-management/index.md))
+-   Work with product manager to create technical architecture based on the PRD document (ref: [PM Handbook](/product-management/index.md))
 -   Work with product manager to plan the work and allocate it among team members
 -   Proactively monitor progress on each ticket in the sprint, whether assigned to you or others, and ensure team completes them by the sprint exit
 -   Review ALL PRs of the team members

--- a/engineering/onboarding-fresher.md
+++ b/engineering/onboarding-fresher.md
@@ -9,7 +9,7 @@ This document assumes that you have no or minimal experience with this stack of 
 Please ensure that you have reviewed [company working principles](https://github.com/jalantechnologies/handbook?tab=readme-ov-file#working-at-jalan-technologies). Read it twice, in detail, as 99% associates often overlook the details and often causes mismatch of expectations.
 
 ### How we think about software development
-Please ensure that you have reviewed [this article on Github](https://github.com/jalantechnologies/handbook/blob/main/engineering/index.md) how we think about software development, and best practices we recommend to follow.
+Please ensure that you have reviewed [this article on Github](/engineering/index.md) how we think about software development, and best practices we recommend to follow.
 
 ### Mentorship
 At the time of joining, you will be assigned a mentor who will be your single point of contact on Engineering as you go through the onboarding. If you have not been assigned a mentor, please reach out to HR to ask for your mentor. You are expected to share your daily status update on `Onboarding (Engineering)` channel which helps your mentor to follow your progress. Your mentor will also meet once a week in person to give you feedback, answer any questions if any.
@@ -77,7 +77,7 @@ Note: We expect you to finish this in 2 weeks, assuming you are putting in at le
   - File names should always be in lowercase. Use hyphens (-) to separate words. For example: `todo-controller.ts`
 
 ###  Raise a PR
-We encourage you to raise your PR daily, push your changes, once you are done for the day, a PR on Github to merge these changes against the develop branch. Please see raising [pull request etiquette](https://github.com/jalantechnologies/handbook/blob/main/engineering/pr-etiquette.md).
+We encourage you to raise your PR daily, push your changes, once you are done for the day, a PR on Github to merge these changes against the develop branch. Please see raising [pull request etiquette](/engineering/pr-etiquette.md).
 
 ### Important soft skills to pay attention to
 1.  Avoiding repetition of mistakes: While mistakes are a natural part of the learning process, we value individuals who can take feedback, learn from their mistakes and apply that knowledge to prevent repetition.

--- a/engineering/pr-etiquette.md
+++ b/engineering/pr-etiquette.md
@@ -47,8 +47,8 @@ TLDR: Don't be lazy.
 - **Set meta info**: Set reviewers, assignee (usually to self) as well as label (task, bug, documentation etc)
 - **Lint / Analyze / Test**: Ensure that your PR meets coding standard of your code base (linting), has no bad code (static analyzer) and does not break any automated tests (test). Often these are covered by your CI pipeline, in case that is setup.
 - **Self Review**: This is a big one. Please review your PR by self first before asking for a review. This often catches 90% of nits and makes it easier for reviewer to focus on things that matters. These points are also applicable while reviewing fellow developers' PRs.
-  - **Check Description Message**: Verify that the description aligns with the defined process mentioned in [This](https://github.com/jalantechnologies/handbook/blob/main/engineering/pr-etiquette.md) document above and is comprehensive.
-  - **Check Commit Messages**: Ensure commit messages are clear, meaningful, and follow the established format mentioned in [This](https://github.com/jalantechnologies/handbook/blob/main/engineering/pr-etiquette.md) document above.
+  - **Check Description Message**: Verify that the description aligns with the defined process mentioned in [This](/engineering/pr-etiquette.md) document above and is comprehensive.
+  - **Check Commit Messages**: Ensure commit messages are clear, meaningful, and follow the established format mentioned in [This](/engineering/pr-etiquette.md) document above.
   - **Preview Demo Evidence**: Include demo videos or screenshots from the preview environment to validate visual or functional changes.
   - **No Defaults**: Avoid using default values unless absolutely necessary. Provide context or documentation for defaults used.
   - **Avoid Magic Numbers**: Replace magic numbers with named constants or configurations.

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -17,11 +17,11 @@ The rest of the section talks in brief about each of the steps.
 
 #### 1. Understanding Problem
 
-**Goal: Understand the problem and start the product requirement document (PRD) using this [template](https://github.com/jalantechnologies/handbook/blob/main/product-management/PRD%20Template.md)**
+**Goal: Understand the problem and start the product requirement document (PRD) using this [template](/product-management/PRD%20Template.md)**
 
 The first step is to figure out what problem to solve. This is the **hardest part**. If you get this wrong, everything else will result in waste. At Better, often your customer would tell you the problem statement(s). [5 Whys](https://en.wikipedia.org/wiki/Five_whys) is a good interrogative technique to use while doing the discovery and understanding the problem statement.
 
-Once you understand the problem, create a product requirement document (PRD) using this [template](https://github.com/jalantechnologies/handbook/blob/main/product-management/PRD%20Template.md) and fill in the relevant section to document the problem statement.
+Once you understand the problem, create a product requirement document (PRD) using this [template](/product-management/PRD%20Template.md) and fill in the relevant section to document the problem statement.
 
 #### 2. Evangelize Solution
 
@@ -74,5 +74,5 @@ PM should validate the behaviour against PRD and if it is indeed a bug, s/he sho
 
 ## Important Links:
 
-#### 1. [PM Onboarding](https://github.com/jalantechnologies/handbook/blob/main/product-management/onboarding.md)
-#### 2. [PRD Template](https://github.com/jalantechnologies/handbook/blob/main/product-management/PRD%20Template.md)
+#### 1. [PM Onboarding](/product-management/onboarding.md)
+#### 2. [PRD Template](/product-management/PRD%20Template.md)

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -1,6 +1,6 @@
 ### Onboarding
 
-#### Understand the product and [product management processes](https://github.com/jalantechnologies/handbook/blob/main/product-management/index.md) to take charge of the scrum
+#### Understand the product and [product management processes](/product-management/index.md) to take charge of the scrum
 
 ##### Day 1: Introduction and Orientation
 


### PR DESCRIPTION
# Fix internal links for GitHub Pages compatibility

Updated all internal links across multiple handbook files to use relative paths for proper navigation on GitHub Pages.

---

## ✅ Changes Made

- Fixed internal links in:
  - `README.md`
  - `engineering/index.md`
  - `engineering/lead.md`
  - `engineering/onboarding-fresher.md`
  - `engineering/pr-etiquette.md`
  - `product-management/index.md`
  - `product-management/onboarding.md`
- Ensured that `.md` files within the repo now use relative paths instead of absolute URLs where possible.
- Verified links for Product Management and Engineering sections, including PRD Template and Onboarding pages.

---

## 🔍 Why is this change needed?

- Current internal links were pointing to GitHub URLs directly.
- This caused broken navigation when viewed through GitHub Pages.
- Updating them to relative paths ensures compatibility with the GitHub Pages site and improves maintainability.

---