### PR TITLE
chore: Clarify Daily Status Update Section and Add PPP Examples

### DIFF
--- a/common/working_at_better.md
+++ b/common/working_at_better.md
@@ -8,12 +8,45 @@ Set your working hours (and keep it up to date) in your status message on MS tea
 ### Daily Status Update
 Start your day by sharing a status update on your primary project workspace with:
 
-- Plan – What you'll work on
-- Problems – Any blockers
+- Plan – What you'll work on today and your intended outcomes or deliverables.
+- Problems – Any blockers or issues preventing progress.
 
-At the end of the day, reply to the same thread with what you completed. This keeps everyone aligned and shows follow-through. Please make sure to include as much detail as possible, hyperlink artifacts being referred in the message so its easy to follow your progress without talking to you.
+At the end of the day, reply to the same thread with what you completed. This keeps everyone aligned and shows follow-through. Your updates should be outcome-oriented and reference PRs, issues, or project artifacts with hyperlinks as appropriate, making it easy for others to follow your work without extra conversation.
 
 Daily updates are part of our work culture. If you don’t post them, we usually assume you're not working.
+
+#### Examples
+
+**Good PPP Example:**
+
+Plan:
+- Add unit tests for AWS ECR cleanup logic ([PR #234](#)), ensuring edge cases are handled.
+- Deploy cleanup code to staging and verify artifact removal ([Issue #88](#)).
+
+Problems:
+- Awaiting review on infra access request (ticket #567).
+
+_Progress (EOD reply):_
+- All tests passed and cleanup logic merged ([PR #234](#)).
+- Verified artifact deletion in staging; no issues found.
+
+**Bad PPP Example:**
+
+Plan:
+- Read PPPs.
+- Check emails.
+
+Problems:
+- Waiting on ABC's update.
+
+_Progress:_
+- Finished reading PPPs.
+- No further updates.
+
+***
+
+**Key Point:**  
+Always focus on clear, outcome-driven plans and actual deliverables in both your morning and EOD updates. Avoid listing process steps or admin/checklist activities on their own.
 
 ## Common Work Channels:
 Other than your primary project workspace, these are common channels that you should know:

--- a/common/working_at_better.md
+++ b/common/working_at_better.md
@@ -15,6 +15,7 @@ At the end of the day, reply to the same thread with what you completed. This ke
 
 Daily updates are part of our work culture. If you don’t post them, we usually assume you're not working.
 
+
 #### Examples
 
 **Good PPP Example:**
@@ -37,7 +38,7 @@ Plan:
 - Check emails.
 
 Problems:
-- Waiting on ABC's update.
+- Waiting for teammate's update.
 
 _Progress:_
 - Finished reading PPPs.

--- a/common/working_at_better.md
+++ b/common/working_at_better.md
@@ -11,7 +11,7 @@ Start your day by sharing a status update on your primary project workspace with
 - Plan – What you'll work on today and your intended outcomes or deliverables.
 - Problems – Any blockers or issues preventing progress.
 
-At the end of the day, reply to the same thread with what you completed. This keeps everyone aligned and shows follow-through. Your updates should be outcome-oriented and reference PRs, issues, or project artifacts with hyperlinks as appropriate, making it easy for others to follow your work without extra conversation.
+At the end of the day, reply to the same thread with what you completed. This keeps everyone aligned and shows follow-through. Your updates should be outcome-oriented and as much details as possible, such as reference PRs, issues, or project artifacts with hyperlinks, making it easy for others to follow your work without extra conversation.
 
 Daily updates are part of our work culture. If you don’t post them, we usually assume you're not working.
 


### PR DESCRIPTION
### Why is this change needed?

The previous “Daily Status Update” guidance led to confusion about what a meaningful daily status update should contain, especially for new engineers. Some engineers interpreted routine process steps or personal internal work as sufficient for status updates, which reduced clarity and value for the team. This PR clarifies instructions and provides explicit “good” vs “bad” examples, ensuring updates are always outcome-driven and actionable for future contributors.

### Changes

- Revised handbook content for the “Daily Status Update” section in `working_at_better.md` file.
- Added clear expectations for daily posts and EOD replies.
- Included concise sample PPPs (good and bad).

### Screenshots

**Before**
<img width="1718" height="295" alt="Screenshot from 2025-10-27 14-21-31" src="https://github.com/user-attachments/assets/97a81c8b-9ec5-4fe0-b5ad-83b7c40a2a12" />

**After**
<img width="1674" height="935" alt="Screenshot from 2025-10-27 14-21-02" src="https://github.com/user-attachments/assets/4db75de0-43a0-4619-a3a1-9f9eebb8c6df" />

### Tests

- [x] Markdown file previewed to ensure formatting renders correctly.

- [x]  Example PPPs reviewed for clarity and completeness