### PR TITLE
Update of onboarding doc

### DIFF
--- a/product-management/index.md
+++ b/product-management/index.md
@@ -58,7 +58,7 @@ We follow an Agile process with **2-week sprints**, and PMs are expected to lead
 
 - **Feature acceptance (Duration: Ongoing, When: During the sprint)**: During the sprint, you should verify all the PRs and provide "PM Acceptance" for the engineering team to merge and deploy the feature on production. All the reviews and feedback should be submitted within PR on GitHub. 
 
--   **Sprint Exit (Duration: 60 minutes, When: Last day of sprint)**: In the morning of the last day of the sprint, send the engineering team a reminder to ensure that they focus on internal feedback and preparing for the demo on the staging environment. You should also prepare a Sprint Review in Confluence tabels summarizing the sprint output.
+-   **Sprint Exit (Duration: 60 minutes, When: Last day of sprint)**: In the morning of the last day of the sprint, send the engineering team a reminder to ensure that they focus on internal feedback and preparing for the demo on the staging environment. You should also prepare a Sprint Review in [Confluence](https://www.loom.com/share/94541e5d80bd4c06815891b46ebf5e31) summarizing the sprint output.
 
 -   **Sprint Retro (Duration: 30 minutes, When: 2 days after sprint exit)**: The goal of this meeting (should plan within 2-3 days of sprint exit) is to reflect on what went well and areas to improve for the sprint with clear action items.
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -85,20 +85,13 @@ PM should validate the behaviour against PRD and if it is indeed a bug, s/he sho
 
 -   Once the changes are deployed to production, verify it once and notify the person who reported the bug.
 
-#### 5. Collaboration Tools
+### Collaboration Tools
 
 **Goal: Ensure smooth, transparent, and structured collaboration throughout the project.**
 
-Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices. Please click [here](https://teams.microsoft.com/l/channel/19%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2/tab%3A%3A72fc109c-5b38-499a-b9ff-53e6558901a4?context=%7B%22channelId%22%3A%2219%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2%22%7D&tenantId=79836b2a-53cc-4854-81b4-ba2d7c9f2726) to read more. 
+At Better, we use several tools to support project execution and team communication:
 
-*Tools Overview*
+1. **[JIRA](/product-management/jira)**: For task and ticket tracking
+3. **[MS Teams](/product-management/ms-teams)**: For internal communication with the team and stakeholders
 
-1. Jira: JIRA: For task and ticket tracking
-2. Confluence: For all product and project documentation
-3. MS Teams/ Slack: For internal communication with the team and stakeholders
-4. GitHub: To approve feature release
-
-## Important Links:
-
-#### 1. [PM Onboarding](/product-management/onboarding)
-#### 2. [PRD Template](/product-management/PRD%20Template)
+Each tool plays a specific role in maintaining transparency and structure across your projects. Click the links above to learn more about how to use each tool effectively.

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -85,31 +85,17 @@ PM should validate the behaviour against PRD and if it is indeed a bug, s/he sho
 
 -   Once the changes are deployed to production, verify it once and notify the person who reported the bug.
 
-#### 5. Understanding Communications
+#### 5. Collaboration Tools
 
-**Goal: Ensure smooth, transparent, and structured collaboration through the project’s MS Teams setup.**
+**Goal: Ensure smooth, transparent, and structured collaboration throughout the project.**
 
-Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices.
+Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices. Please click [here](add link----) to read more. 
 
-*Channel Overview*
+*Tools Overview*
 
-1. General Channel: Central hub for team-wide communication and stakeholder interactions
-    1.1 Use Cases: Daily PPPs, product discussions, leave updates and access important documents
-
-2. Engineering Channel: Space for all technical discussions and knowledge sharing.
-	2.1 Use Cases: Code reviews, architecture debates, sharing documentation.
-
-3. PR Review Channel: Streamline and centralize the pull request/ feature review process for product and engineering.
-	3.1 Use Cases: Submit PRs for review.
-
-4. QA Channel: Track QA notes, bug reports, and testing outcomes.
-	4.1 Use Cases: Share bug reports with JIRA links and discuss fixes and QA verification steps
-
-5. Sprint Planning & Exit Channel: Manage sprint ceremonies, outcomes, and documentation.
-	5.1 Use Cases: Share sprint goals, demos, and retrospectives
-
-6. Alert Channel: Monitor production issues through automated alerts.
-	6.1 Use Cases: Receive alerts from monitoring tools
+1. Jira: JIRA: For task and ticket tracking
+2. Confluence: For all product and project documentation
+3. MS Teams/ Slack: For internal communication with the team and stakeholders
 
 ## Important Links:
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -62,6 +62,8 @@ We follow an Agile process with **2-week sprints**, and PMs are expected to lead
 
 -   **Sprint Retro (Duration: 30 minutes, When: 2 days after sprint exit)**: The goal of this meeting (should plan within 2-3 days of sprint exit) is to reflect on what went well and areas to improve for the sprint with clear action items.
 
+-   **Monitoring Alerts & Proactive Bug Management (Duration: Ongoing, When: Daily)**: Monitor the alerts channel consistently to maintain zero alerts as the ideal state. Analyze any incoming alerts, assess their priority (P0, P1, P2), and plan remediation work if needed. Ensure proper alerts are configured and routed to the channel so the team stays informed of production/ preview issues in real-time. 
+
 #### 4. Measure, Learn & Improve
 
 **Goal: Observe feature usage, learn, and improve.**

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -1,15 +1,27 @@
 ## Product Management:
 
+### Goal of This Document
+
+The purpose of this document is to ensure that before starting any new project, you have complete clarity on the processes, expectations, and communication flow required to execute effectively.
+
+By the start of every project, you should be able to confidently answer the following:
+
+1. Do I have a clear understanding of how to initiate a new project- including all prerequisites, documentation, and approvals needed before kickoff?
+2. Do I fully understand how the feature development, review, and release cycles are structured and managed?
+3. Do I know which communication channels are to be used for specific types of discussions, updates, and escalations?
+4. Am I aligned on the product vision, target users, and key business metrics that define success for this project?
+5. Have I identified and connected with all relevant stakeholders, and do I understand their roles, responsibilities, and expectations from the product team?
+
 ### Overview
 
-We think the product manager's role is that of a driver on a bus full of passengers. They have to take everyone with them and lead the bus to the right destination while creating a delightful experience throughout the journey.
+We believe a Product Manager’s role is much like a driver steering a bus full of passengers, leading everyone toward the right destination while ensuring a smooth and engaging journey along the way.
 
-At Better, a product manager:
+At Better, a Product Manager:
 
 1. Works with customer to understand their problems and evangelize solution
-2. Works with a product designer to create a delightful experience for the solution
-3. Works with engineering to bring the solution to life
-4. Repeat steps 1-3 based on data and intuition
+2. Collaborates with designers to craft delightful user experiences.
+3. Partners with engineers to bring those solutions to life.
+4. Continuously iterates on all of the above, guided by data, feedback, and intuition.
 
 It is one of the **hardest jobs** because even though you don't have official authority on engineering, design or customer, you need to inspire them in such a way that they respect you and see you as a leader. This is a title not given but earned.
 
@@ -37,7 +49,8 @@ Once the solution and KPIs are agreed upon, update the PRD document.
 
 **Goal: Work with engineering to plan and execute.**
 
-Once the problem, solution, and KPIs are documented, you should share the document with the tech lead and/or engineers and ask him/her to design the solution and help break down the work into small technical tasks with rough estimates. You should create [JIRA](https://www.atlassian.com/software/jira) tickets based on those work items. For planning purposes, we use agile methodology. Our sprints are 2 weeks long and we recommend product manager conduct the following scrum ceremonies:
+Once the problem, solution, and KPIs are documented, you should share the document with the tech lead and/or engineers and ask him/her to design the solution and help break down the work into small technical tasks with rough estimates. You should create [JIRA](https://www.atlassian.com/software/jira) tickets based on those work items. For planning purposes, we use agile methodology. 
+We follow an Agile process with **2-week sprints**, and PMs are expected to lead or participate in the following ceremonies:
 
 -   **Sprint planning (Duration: 60 minutes, When: 2 days before the sprint starts)**: In the sprint planning, you present the work items to the Tech Lead that you would like the engineering team to achieve. This is an opportunity for the Tech Lead to ask questions and for you to get his buyoff on the plan.
 
@@ -71,6 +84,32 @@ PM should validate the behaviour against PRD and if it is indeed a bug, s/he sho
 -   Work with the lead to get the product fixed
 
 -   Once the changes are deployed to production, verify it once and notify the person who reported the bug.
+
+#### 5. Understanding Communications
+
+**Goal: Ensure smooth, transparent, and structured collaboration through the project’s MS Teams setup.**
+
+Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices.
+
+*Channel Overview*
+
+1. General Channel: Central hub for team-wide communication and stakeholder interactions
+    1.1 Use Cases: Daily PPPs, product discussions, leave updates and access important documents
+
+2. Engineering Channel: Space for all technical discussions and knowledge sharing.
+	2.1 Use Cases: Code reviews, architecture debates, sharing documentation.
+
+3. PR Review Channel: Streamline and centralize the pull request/ feature review process for product and engineering.
+	3.1 Use Cases: Submit PRs for review.
+
+4. QA Channel: Track QA notes, bug reports, and testing outcomes.
+	4.1 Use Cases: Share bug reports with JIRA links and discuss fixes and QA verification steps
+
+5. Sprint Planning & Exit Channel: Manage sprint ceremonies, outcomes, and documentation.
+	5.1 Use Cases: Share sprint goals, demos, and retrospectives
+
+6. Alert Channel: Monitor production issues through automated alerts.
+	6.1 Use Cases: Receive alerts from monitoring tools
 
 ## Important Links:
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -96,6 +96,7 @@ Each project team at Better has a dedicated MS Teams workspace organized into ch
 1. Jira: JIRA: For task and ticket tracking
 2. Confluence: For all product and project documentation
 3. MS Teams/ Slack: For internal communication with the team and stakeholders
+4. GitHub: To approve feature release
 
 ## Important Links:
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -89,7 +89,7 @@ PM should validate the behaviour against PRD and if it is indeed a bug, s/he sho
 
 **Goal: Ensure smooth, transparent, and structured collaboration throughout the project.**
 
-Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices. Please click [here](add link----) to read more. 
+Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices. Please click [here]([here](https://teams.microsoft.com/l/channel/19%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2/tab%3A%3A72fc109c-5b38-499a-b9ff-53e6558901a4?context=%7B%22channelId%22%3A%2219%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2%22%7D&tenantId=79836b2a-53cc-4854-81b4-ba2d7c9f2726)) to read more. 
 
 *Tools Overview*
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -58,7 +58,7 @@ We follow an Agile process with **2-week sprints**, and PMs are expected to lead
 
 - **Feature acceptance (Duration: Ongoing, When: During the sprint)**: During the sprint, you should verify all the PRs and provide "PM Acceptance" for the engineering team to merge and deploy the feature on production. All the reviews and feedback should be submitted within PR on GitHub. 
 
--   **Sprint Exit (Duration: 60 minutes, When: Last day of sprint)**: In the morning of the last day of the sprint, send the engineering team a reminder to ensure that they focus on internal feedback and preparing for the demo on the staging environment. You should also prepare a Sprint Review in [Confluence](https://www.loom.com/share/94541e5d80bd4c06815891b46ebf5e31) summarizing the sprint output.
+-   **Sprint Exit (Duration: Async, When: Last day of sprint)**: On the last day of the sprint, share a sprint summary document in [Confluence](https://jalantechnology.sharepoint.com/:w:/r/sites/Better9/_layouts/15/doc2.aspx?sourcedoc=%7B58a4d4d5-2a33-4a1a-a9f5-245d51fc9f11%7D&action=editnew) that outlines the sprint output, completed work, and key metrics. The engineering team should review their tickets, record any necessary updates using Loom, and submit questions asynchronously. This async approach allows the team to reflect on their work at their own pace while maintaining transparency.
 
 -   **Sprint Retro (Duration: 30 minutes, When: 2 days after sprint exit)**: The goal of this meeting (should plan within 2-3 days of sprint exit) is to reflect on what went well and areas to improve for the sprint with clear action items.
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -89,7 +89,7 @@ PM should validate the behaviour against PRD and if it is indeed a bug, s/he sho
 
 **Goal: Ensure smooth, transparent, and structured collaboration throughout the project.**
 
-Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices. Please click [here]([here](https://teams.microsoft.com/l/channel/19%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2/tab%3A%3A72fc109c-5b38-499a-b9ff-53e6558901a4?context=%7B%22channelId%22%3A%2219%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2%22%7D&tenantId=79836b2a-53cc-4854-81b4-ba2d7c9f2726)) to read more. 
+Each project team at Better has a dedicated MS Teams workspace organized into channels with clear purposes and best practices. Please click [here](https://teams.microsoft.com/l/channel/19%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2/tab%3A%3A72fc109c-5b38-499a-b9ff-53e6558901a4?context=%7B%22channelId%22%3A%2219%3AnrFEZnY-fD1cT-cW2jIBwN2CsqsMSJjEa0laGwqWIz01%40thread.tacv2%22%7D&tenantId=79836b2a-53cc-4854-81b4-ba2d7c9f2726) to read more. 
 
 *Tools Overview*
 

--- a/product-management/index.md
+++ b/product-management/index.md
@@ -58,7 +58,7 @@ We follow an Agile process with **2-week sprints**, and PMs are expected to lead
 
 - **Feature acceptance (Duration: Ongoing, When: During the sprint)**: During the sprint, you should verify all the PRs and provide "PM Acceptance" for the engineering team to merge and deploy the feature on production. All the reviews and feedback should be submitted within PR on GitHub. 
 
--   **Sprint Exit (Duration: 60 minutes, When: Last day of sprint)**: In the morning of the last day of the sprint, send the engineering team a reminder to ensure that they focus on internal feedback and preparing for the demo on the staging environment. You should also prepare the ["Sprint Review"](https://jalantechnology.sharepoint.com/:p:/s/JTC/Ea0gpWXBwy1LixBUfPo2qNYBrAaK3Ju07bgEkjCbQhZVag?e=1R2YK8) slides summarizing the sprint output.
+-   **Sprint Exit (Duration: 60 minutes, When: Last day of sprint)**: In the morning of the last day of the sprint, send the engineering team a reminder to ensure that they focus on internal feedback and preparing for the demo on the staging environment. You should also prepare a Sprint Review in Confluence tabels summarizing the sprint output.
 
 -   **Sprint Retro (Duration: 30 minutes, When: 2 days after sprint exit)**: The goal of this meeting (should plan within 2-3 days of sprint exit) is to reflect on what went well and areas to improve for the sprint with clear action items.
 

--- a/product-management/jira.md
+++ b/product-management/jira.md
@@ -105,8 +105,13 @@ Title: Feature: User Authentication via Google SSO
    - User profile is automatically populated from Google account
    - Error handling for failed OAuth is implemented
    - Feature works on desktop and mobile browsers
-```
 
+4. PRD Link:
+   - So that the engineer working has better perspective of scope of work
+
+5. Figma Link:
+   - Attach figma file if the ticekt requires a design change
+```
 #### Bug Ticket Format
 
 **Title:** `Bug: Description of bug`
@@ -116,24 +121,33 @@ Title: Feature: User Authentication via Google SSO
 1. **Description of bug** - What is broken?
 2. **Steps to reproduce** - How can we reproduce the issue?
 3. **Expected behaviour** - What should happen?
+4. **Actual behaviour** - What is currently happening?
+5. **PRD Link** - Link to the PRD to ensure acceptance criteria alignment
+6. **Additional context** - Environment, browser/device affected, screenshots, or logs
+
+**Note:** If the bug reveals missing requirements not covered in the initial PRD acceptance criteria, file an enhancement ticket instead and update the PRD accordingly, sharing the link in both tickets for traceability.
 
 **Example:**
 
 ```
-Title: Bug: Login page crashes on mobile
+Title: Bug: User profile data not saving on form submission
 
 1. Description of bug:
-   The login page crashes when users submit the login form on iOS devices.
+    User profile updates are lost when submitting the edit profile form, though success message appears.
 
 2. Steps to reproduce:
-   Step 1: Open the app on an iOS device
-   Step 2: Navigate to the login page
-   Step 3: Enter email and password
-   Step 4: Tap the "Login" button
-   Step 5: Page crashes with error message
+    Step 1: Log in to user account
+    Step 2: Navigate to Settings > Profile
+    Step 3: Update name field to "John Doe"
+    Step 4: Click "Save Changes" button
+    Step 5: Refresh page or navigate away
 
 3. Expected behaviour:
-   User should be logged in and redirected to the dashboard without any errors.
+    Updated name should persist in the database and display on page refresh.
+
+4. Actual behaviour:
+    Name reverts to original value after refresh; database record unchanged.
+```
 ```
 
 **Guidelines:**

--- a/product-management/jira.md
+++ b/product-management/jira.md
@@ -1,0 +1,183 @@
+# JIRA - Task and Ticket Tracking
+
+## Overview
+
+JIRA is a project management and issue tracking tool used for task and ticket tracking throughout the product development lifecycle. As a Product Manager at Better, JIRA is your primary tool for managing work items, tracking progress, and maintaining transparency with the engineering team.
+
+## Purpose
+
+JIRA helps you:
+- Break down PRD requirements into manageable technical tasks
+- Track the status of work items throughout the sprint
+- Maintain clear communication between PM, Engineering, Design, and QA teams
+- Document bugs, defects, and feature requests
+- Prioritize work based on business impact and urgency
+
+## Key Use Cases
+
+### 1. Creating and Managing User Stories
+
+**When:** After PRD is finalized and solution is approved with engineering
+
+**How to:**
+- Create a new JIRA ticket for each major feature or user story
+- Write clear acceptance criteria based on your PRD
+- Link related tickets and dependencies
+- Assign to the appropriate team member or leave unassigned for sprint planning
+
+### 2. Breaking Down Work into Technical Tasks
+
+**When:** During sprint planning meetings with Tech Lead
+
+**How to:**
+- Work with the team to identify technical subtasks required for each user story
+- Add rough time estimates for each task
+
+### 3. Bug and Defect Tracking
+
+**When:** Bugs are reported by QA, customers, or team members
+
+**How to:**
+- File a JIRA ticket immediately
+- Validate the behavior against the PRD to confirm it's a bug
+- Assign priority level:
+  - **P0:** Critical - Stop everything and fix this first
+  - **P1:** High - Fix soon, acceptable in current sprint
+  - **P2:** Low - Backlog item, can be addressed later
+- Update PRD if the bug reveals missing requirements
+- Assign to engineering team for resolution
+
+### 4. Sprint Tracking and Status Updates
+
+**When:** Throughout the sprint
+
+**How to:**
+- Monitor ticket status daily (To Do → In Progress → In Review → PM Review → Done)
+- Update priority or scope if sprint dynamics change
+- Use JIRA board to communicate sprint progress in daily standups
+- Close tickets only when all acceptance criteria are met and tested
+
+### 5. Feature Requests and Enhancements
+
+**When:** Ongoing, from customers or internal stakeholders
+
+**How to:**
+- Log feature requests as JIRA tickets
+- Prioritize and plan them into future sprints
+- Link to related features or epics for better organization
+- Keep backlog organized and visible to stakeholders
+
+## Best Practices
+
+### Ticket Naming and Description
+
+Use the following format for ticket names:
+
+#### Feature Ticket Format
+
+**Title:** `Feature: Description`
+
+**Description should include:**
+
+1. **Define the feature** - What is the feature and why are we building it?
+2. **User flow** - Tell the user steps/journey through the feature
+3. **Acceptance Criteria** - What are the acceptance criteria for the feature?
+
+**Example:**
+
+```
+Title: Feature: User Authentication via Google SSO
+
+1. Define the feature:
+   Allow users to sign up and login using Google credentials to provide a seamless authentication experience.
+
+2. User flow:
+   Step 1: User clicks "Sign Up with Google" button on login page
+   Step 2: User is redirected to Google OAuth consent screen
+   Step 3: User grants permission to access basic profile information
+   Step 4: User is redirected back to the app and logged in
+   Step 5: User dashboard is displayed with profile information pre-filled
+
+3. Acceptance Criteria:
+   - Google OAuth flow is successfully implemented
+   - User can sign up using Google credentials
+   - User can login using Google credentials
+   - User profile is automatically populated from Google account
+   - Error handling for failed OAuth is implemented
+   - Feature works on desktop and mobile browsers
+```
+
+#### Bug Ticket Format
+
+**Title:** `Bug: Description of bug`
+
+**Description should include:**
+
+1. **Description of bug** - What is broken?
+2. **Steps to reproduce** - How can we reproduce the issue?
+3. **Expected behaviour** - What should happen?
+
+**Example:**
+
+```
+Title: Bug: Login page crashes on mobile
+
+1. Description of bug:
+   The login page crashes when users submit the login form on iOS devices.
+
+2. Steps to reproduce:
+   Step 1: Open the app on an iOS device
+   Step 2: Navigate to the login page
+   Step 3: Enter email and password
+   Step 4: Tap the "Login" button
+   Step 5: Page crashes with error message
+
+3. Expected behaviour:
+   User should be logged in and redirected to the dashboard without any errors.
+```
+
+**Guidelines:**
+- Use clear, concise titles that describe the user story
+- Include all required sections in the ticket description
+- Reference the PRD in the ticket description
+- Add any relevant context or customer feedback
+- Attach screenshots or video recordings for bugs when possible
+
+### Prioritization
+
+- Regularly review and prioritize tickets with the team
+- Use consistent priority labeling (P0, P1, P2, etc.)
+- Adjust priorities based on sprint goals and customer impact
+- Communicate priority changes to the team promptly
+
+### Sprint Hygiene
+
+- Ensure all sprint tasks are captured in JIRA before sprint planning
+- Close completed tickets promptly after testing and verification
+- Archive or move incomplete tasks to backlog at sprint exit
+- Keep JIRA updated as the single source of truth for sprint status
+
+### Collaboration
+
+- Use JIRA comments to discuss approach and updates
+- Mention team members using @mentions for visibility
+- Link JIRA tickets in MS Teams when seeking feedback or updates
+- Review JIRA board together during standup meetings
+
+## JIRA Workflow at Better
+
+```
+To Do → In Progress → In Review → PM Review → Done
+  ↓
+(Optional: Blocked/On Hold)
+```
+
+**To Do:** Ticket is ready to be worked on  
+**In Progress:** Team member is actively working on the ticket  
+**In Review:** Work is complete and pending PM/QA review  
+**PM Review:** PM has approved and ticket is ready for deployment   
+**Done:** Ticket is tested, verified, and deployed to production  
+
+---
+
+For questions or help with JIRA workflow, reach out to your Tech Lead or Product Manager Lead.

--- a/product-management/ms-teams.md
+++ b/product-management/ms-teams.md
@@ -1,0 +1,69 @@
+
+# MS Teams Communication Guide
+
+## 1. General Channel
+
+**Purpose:** Central hub for project-wide discussions.
+
+**Use Cases:**
+- Daily PPP updates
+- Sharing important documents
+- Non-technical team conversations
+- High-level product discussions
+- Leave updates or availability notes
+- Announcements relevant to all stakeholders
+
+## 2. Engineering Channel
+
+**Purpose:** Technical discussions among developers and tech leads.
+
+**Use Cases:**
+- Architecture decisions
+- Technical Q&A
+- Sharing code snippets or technical references
+- Discussion of implementation approaches
+- Engineering-specific updates
+- Posting links to technical documents
+
+## 3. PR Review Channel
+
+**Purpose:** To streamline and centralize pull request and code review communication.
+
+**Use Cases:**
+- Sharing PR links for review
+- Tagging PM/QA for acceptance or testing
+- Posting review feedback
+- Notifying team when PR is merged
+- Tracking pending reviews
+
+## 4. QA Channel
+
+**Purpose:** Central space for all QA-related communication.
+
+**Use Cases:**
+- Reporting bugs with JIRA links
+- Sharing QA test results or notes
+- Clarifying acceptance criteria
+- Discussing fixes and verification steps
+- Tracking testing status throughout the sprint
+
+## 5. Sprint Planning & Exit Channel
+
+**Purpose:** To coordinate sprint ceremonies and manage sprint-related documentation.
+
+**Use Cases:**
+- Posting sprint goals
+- Sharing sprint planning notes
+- Uploading demo videos/screenshots
+- Sharing sprint exit summary and outcomes
+- Posting sprint retrospective notes
+
+## 6. Alerts Channel
+
+**Purpose:** Automated updates from monitoring and observability tools.
+
+**Use Cases:**
+- Receiving production alerts
+- Tracking downtime or issues
+- Notifying engineering and PM instantly when something breaks
+- Prompt follow-ups on urgent alerts

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -29,9 +29,9 @@ The goal of this document is to ensure that by the start of every project, you c
 
 #### Day 3: Sprint Meetings Initiation
 
-- Attend the daily stand-up meeting to observe and understand the dynamics of the team.
+- Attend the daily stand-up meeting to observe, understand the dynamics of the team and learn about the daily progress.
 - Introduction to sprint planning meetings and an overview of the agile development process.
-- Participate in a retrospective meeting to understand how the team reflects on the past sprint and improvement plans.
+- Participate/ observe a retrospective meeting after every sprint to understand how the team reflects on the past sprint and improvement plans.
 
 #### Day 4: PRD Review and Hands-On Product Exploration 
 

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -39,7 +39,7 @@ layout: default
 
 At the end of the first week of onboarding, you should be ready to lead the sprint meetings, outlining goals, priorities, and expectations for the upcoming sprint.
 
-#### Walkthrough Videos
+#### Walkthrough Video
 
 For walkthroughs, watch these videos:  
 [Project setup guide for PMs](https://www.loom.com/share/a6da5fe2bb2e4be49110baaaf99ac69c)  

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -46,3 +46,9 @@ The goal of this document is to ensure that by the start of every project, you c
 - Work closely with the Product team to refine user stories, clarify requirements, and align on sprint goals.
 
 At the end of the first week of onboarding, you should be ready to lead the sprint meetings, outlining goals, priorities, and expectations for the upcoming sprint.
+
+#### Walkthrough Video
+
+[Team Setup](https://www.loom.com/share/298c63ed2d054fbab55ec7c538054681)
+[JIRA Setup](https://www.loom.com/share/cd85ac99bc7146ffb0cb853150eeae35)
+[Starting a Sprint](https://www.loom.com/share/435e21161edb443983934f3d25c3e455)

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -46,7 +46,3 @@ The goal of this document is to ensure that by the start of every project, you c
 - Work closely with the Product team to refine user stories, clarify requirements, and align on sprint goals.
 
 At the end of the first week of onboarding, you should be ready to lead the sprint meetings, outlining goals, priorities, and expectations for the upcoming sprint.
-
-#### Walkthrough Video
- 
-[Project setup guide for PMs](https://www.loom.com/edit/e7e977685c7a4887942defd3b6a52ffc)

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -4,6 +4,14 @@ layout: default
 
 ### Onboarding
 
+The goal of this document is to ensure that by the start of every project, you can confidently answer the following questions:
+
+	1. Do I know which sprint ceremonies I’m expected to lead or participate in, and what my role is in each?
+	2. Do I have a clear understanding of the daily processes and steps to follow until the project is completed?
+	3. Do I understand all the processes that have been set up for this specific project?
+	4. Have I met all the relevant stakeholders and aligned everyone on the plan of action?
+
+
 #### Understand the product and [product management processes](/product-management/index) to take charge of the scrum
 
 ##### Day 1: Introduction and Orientation
@@ -40,6 +48,5 @@ layout: default
 At the end of the first week of onboarding, you should be ready to lead the sprint meetings, outlining goals, priorities, and expectations for the upcoming sprint.
 
 #### Walkthrough Video
-
-For walkthroughs, watch these videos:  
+ 
 [Project setup guide for PMs](https://www.loom.com/share/a6da5fe2bb2e4be49110baaaf99ac69c)  

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -38,3 +38,8 @@ layout: default
 - Work closely with the Product team to refine user stories, clarify requirements, and align on sprint goals.
 
 At the end of the first week of onboarding, you should be ready to lead the sprint meetings, outlining goals, priorities, and expectations for the upcoming sprint.
+
+#### Walkthrough Videos
+
+For walkthroughs, watch these videos:  
+[Project setup guide for PMs](https://www.loom.com/share/a6da5fe2bb2e4be49110baaaf99ac69c)  

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -49,4 +49,4 @@ At the end of the first week of onboarding, you should be ready to lead the spri
 
 #### Walkthrough Video
  
-[Project setup guide for PMs](https://www.loom.com/share/a6da5fe2bb2e4be49110baaaf99ac69c)  
+[Project setup guide for PMs](https://www.loom.com/edit/e7e977685c7a4887942defd3b6a52ffc)

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -49,6 +49,4 @@ At the end of the first week of onboarding, you should be ready to lead the spri
 
 #### Walkthrough Video
 
-[Team Setup](https://www.loom.com/share/298c63ed2d054fbab55ec7c538054681)
-[JIRA Setup](https://www.loom.com/share/cd85ac99bc7146ffb0cb853150eeae35)
-[Starting a Sprint](https://www.loom.com/share/435e21161edb443983934f3d25c3e455)
+[Starting a Sprint at Better](https://www.loom.com/share/435e21161edb443983934f3d25c3e455)

--- a/product-management/onboarding.md
+++ b/product-management/onboarding.md
@@ -47,6 +47,4 @@ The goal of this document is to ensure that by the start of every project, you c
 
 At the end of the first week of onboarding, you should be ready to lead the sprint meetings, outlining goals, priorities, and expectations for the upcoming sprint.
 
-#### Walkthrough Video
-
-[Starting a Sprint at Better](https://www.loom.com/share/435e21161edb443983934f3d25c3e455)
+#### Walkthrough Video: [Starting a Sprint at Better](https://www.loom.com/share/435e21161edb443983934f3d25c3e455)


### PR DESCRIPTION
Edited the following documents for: 

1. Onboarding doc

- Expanded into a clear Day 1–Day 5 first-week walkthrough for new PMs.
- Makes sprint ceremony ownership explicit (standups, planning, review, retro).
- Adds PRD review tasks, sprint ownership prep and expected outcomes.
- Includes Loom walkthrough link for “Starting a Sprint”.

2. Jira Doc

- Added JIRA walkthrough video link and step-by-step guidance.
- Standardized ticket formats (Feature / Bug) with required sections and examples.
- Documented prioritization (P0/P1/P2), sprint hygiene and collaboration best practices.
- Included the project workflow (To Do → In Progress → In Review → PM Review → Done).

3. MS Teams Doc

- Defined channel taxonomy and purpose (General, Engineering, PR Review, QA, Sprint Planning/Exit, Alerts).
- Listed specific use cases for each channel to reduce noise and improve routing.
- Added guidance for automated alerts and where to post PR/JIRA links.

4. Index Doc

- Refined the Product Management overview and PM responsibilities.
- Documented ceremonies timeline, roles, and expectations (2-week sprints, planning, daily standup, acceptance, sprint exit, retro)
- Added monitoring/alerts responsibilities and defect handling procedure.
- Pointed to JIRA and MS Teams docs as primary collaboration tools.