### PR TITLE
chore: update handbook contact + booking links to btr.group

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - **Better Marketing**: Digital marketing agency to grow businesses using digital channels with art, science and data.
 - **Better AI**: AI first solutions in healthcare, banking, manufacturing and technology sectors.
 
-The rest of the document talks about our values and how we operate. If you have any feedback on how we can improve, please write to Jai at jjalan@bettrhq.com
+The rest of the document talks about our values and how we operate. If you have any feedback on how we can improve, please write to Jai at jjalan@btr.group
 
 ## Company Values
 Over time, we have realized that we cannot serve our customers if we are not operating individually and as a company, without these values:

--- a/common/performance_growth.md
+++ b/common/performance_growth.md
@@ -32,7 +32,7 @@ We also draw a firm line: lying to teammates or clients is non-negotiable and ma
 We offer a one-month notice period to help with transitions and job search support wherever possible.
 
 ## 1:1 with Jai
-We are still a small company, and have a flat hierarchy. 1:1 is a great tool that you can use to bring up your wins, concerns, get feedback or anything that you want to talk related to work. You can book a monthly 1:1 with Jai [here](https://outlook.office.com/bookwithme/user/f60bbd0e6a6144a098592545d9c6e9fb@bettrhq.com/meetingtype/FAMP3-Pqv0Sjyk5uq4scig2?anonymous&ismsaljsauthenabled&ep=mcard). This is your time—use it intentionally.
+We are still a small company, and have a flat hierarchy. 1:1 is a great tool that you can use to bring up your wins, concerns, get feedback or anything that you want to talk related to work. You can book a monthly 1:1 with Jai [here](https://outlook.office.com/bookwithme/user/f60bbd0e6a6144a098592545d9c6e9fb@btr.group/meetingtype/FAMP3-Pqv0Sjyk5uq4scig2?anonymous&ismsaljsauthenabled&ep=mcard). This is your time—use it intentionally.
 
 **What to Bring**:
 1. Your top 1–2 priorities since our last 1:1


### PR DESCRIPTION
## Summary

Updates the handbook's email/booking references from `@bettrhq.com` to `@btr.group`, as part of moving our primary domain to **btr.group**. The btr.group email domain is live on our Microsoft 365 tenant (MX/SPF/autodiscover/DMARC all configured).

Changes (2 references):
- `README.md` — feedback contact `jjalan@bettrhq.com` → `jjalan@btr.group`
- `common/performance_growth.md` — Jai's "Book with me" 1:1 link domain → `@btr.group`

## Notes for reviewer

- Local-parts and the Bookings GUID are unchanged; only the domain is swapped.
- Please confirm `jjalan@btr.group` is the live primary address and the booking page resolves under the new domain before merging (HR/IT sign-off pending).

## Additional Context

Docs-only change; no other handbook references to `bettrhq.com` remain.