### PR TITLE
docs: add AI coding tools usage policy

### DIFF
--- a/common/compensation_benefits.md
+++ b/common/compensation_benefits.md
@@ -6,7 +6,11 @@ Here's what you get when you work at Better.
 We're a fully remote company. You can work from anywhere as long as you have a stable internet connection and overlap with your team for at least 4 working hours a day.
 
 **Laptop Policy**
-We provide laptops to full-time employees (FTEs). This usually takes 2–3 weeks after joining. Please have a personal machine available to work from during this initial period.
+### Tooling & Equipment
+We give you the tools to do your best work.
+
+- **Laptop**: We provide laptops to full-time employees (FTEs). This usually takes 1 month after joining, so please have a personal machine available to work from during this initial period.
+- **AI tools**: AI is core to how we work, so we provide the right tools for your role. Full-time engineers get a paid coding assistant such as Claude Max. Other full-time roles get the AI tools that fit their work — talk to your manager about what you need. Associates use free and student-subsidized tools such as GitHub Copilot, Google Gemini, Google Colab, and Perplexity.
 
 ### Compensation
 Salary is credited on or before the 5th business day of the following month.

--- a/common/compensation_benefits.md
+++ b/common/compensation_benefits.md
@@ -34,6 +34,3 @@ If you're a full-time employee and expecting a child, we offer paid parental lea
 
 ### Learning & Development
 We provide access to paid courses, certifications, and tools that help you grow in your role. If there's something specific you'd like to pursue, discuss it with your manager — we're happy to support learning that adds value to your work.
-
-### AI Tooling
-We provide AI tools appropriate to your role. Full-time employees (FTEs) are given access to tools suited to their work, such as Claude Max. Associates are not provided separate subscriptions for AI tools and are expected to use their student co-pilot subscriptions for AI coding tools such as GitHub Copilot, Claude, and ChatGPT as part of their work.

--- a/common/compensation_benefits.md
+++ b/common/compensation_benefits.md
@@ -31,5 +31,5 @@ If you're a full-time employee and expecting a child, we offer paid parental lea
 ### Learning & Development
 We provide access to paid courses, certifications, and tools that help you grow in your role. If there's something specific you'd like to pursue, discuss it with your manager — we're happy to support learning that adds value to your work.
 
-Subscriptions for AI tools are not provided to associates.
-Associates are expected to make use of their student co-pilot subscriptions for AI coding tools such as GitHub Copilot, Claude, and ChatGPT as part of their work.
+### AI Tooling
+We provide AI tools appropriate to your role. Full-time employees (FTEs) are given access to tools suited to their work, such as Claude Max. Associates are not provided separate subscriptions for AI tools and are expected to use their student co-pilot subscriptions for AI coding tools such as GitHub Copilot, Claude, and ChatGPT as part of their work.

--- a/common/compensation_benefits.md
+++ b/common/compensation_benefits.md
@@ -3,34 +3,34 @@
 Here's what you get when you work at Better.
 
 ### Remote-Friendly Work
-We're a fully remote company. You can work from anywhere as long as you have a stable internet connection and overlap with your team for at least 4 working hours a day.
+We're a fully remote company on a 5-day work week (Monday to Friday). Work from anywhere, as long as you have a stable internet connection and overlap with your team for at least 4 hours a day.
 
-**Laptop Policy**
+### Compensation
+Salary is paid by the 5th business day of the next month.
+
+If you join mid-month, we adjust your first salary for the days you worked. For example, if your salary is INR 50,000 and you join on Jan 12, you'll be paid INR 32,258 (= 50,000 × 20 / 31), credited by Feb 5.
+
 ### Tooling & Equipment
 We give you the tools to do your best work.
 
-- **Laptop**: We provide laptops to full-time employees (FTEs). This usually takes 1 month after joining, so please have a personal machine available to work from during this initial period.
-- **AI tools**: AI is core to how we work, so we provide the right tools for your role. Full-time engineers get a paid coding assistant such as Claude Max. Other full-time roles get the AI tools that fit their work — talk to your manager about what you need. Associates use free and student-subsidized tools such as GitHub Copilot, Google Gemini, Google Colab, and Perplexity.
-
-### Compensation
-Salary is credited on or before the 5th business day of the following month.
-
-If you join in the middle of a month, your salary is prorated based on actual days worked — for example, if your salary is INR 50,000 and you join on Jan 12, you'll be paid INR 32,258 (= 50,000 × 20 / 31), credited by Feb 5.
+- **Laptop**: We provide laptops to full-time employees. This usually takes 2 to 3 weeks after joining, so keep a personal machine handy to work from until then.
+- **AI tools**: AI is core to how we work, so we pay for the right tools for your role. Full-time engineers get a paid coding assistant such as Claude Max. Other full-time roles get the AI tools that fit their work. Ask your manager for what you need. Associates (interns) use the free and student tools available to them, most of which are free with a college ID or student email: [GitHub Copilot](https://education.github.com), [Google Gemini](https://gemini.google/students/), [Google Colab](https://colab.research.google.com), and [Perplexity](https://www.perplexity.ai). Student offers change often, so check the current terms before you sign up.
 
 ### Leaves & Time Off
-All team members are entitled to 12 paid leaves, 6 sick leaves, and 14 public holidays in a year.
+You get 12 paid leaves, 6 sick leaves, and 14 public holidays a year.
 
-Leave starts accruing from your first month — if you join on or before the 15th, you accrue one full day of paid leave that month; if you join after the 15th, you accrue half a day. Unused paid leaves can be carried forward to the next year, up to a maximum of 6 days. Sick leaves expire at year-end and cannot be carried forward.
+You start earning leave from your first month. If you join on or before the 15th, you get a full day for that month. If you join after the 15th, you get half a day.
 
-After completing one year at the company, you become eligible to encash any unused paid leaves. Please note that sick leaves are not eligible for encashment. We do not support taking advance leave — you may only use what you've already earned.
+- **Paid leaves**: At the end of the year, you can carry over up to 6 unused paid leaves. Once you've been here a year, you can also cash out unused paid leaves.
+- **Sick leaves**: These don't carry over and can't be cashed out.
 
-During your notice period, no new leaves are credited and you are expected not to take any time off. If you forget to apply for leave in Keka, we'll auto-adjust it from your balance so there's no confusion.
+You can only take leave you've already earned, so there's no borrowing against future leave. During your notice period, you stop earning new leaves and shouldn't take time off. If you take leave but forget to log it in Keka, we'll deduct it from your balance.
 
 ### Health Insurance
-Full-time employees (FTEs) are covered under a group health plan that includes INR 3,00,000 coverage for you, your spouse, and your children. The plan also includes access to remote doctor consultations.
+Full-time employees get a group health plan with INR 3,00,000 coverage for you, your spouse, and your children. It also includes remote doctor consultations.
 
 ### Parental Leave
-If you're a full-time employee and expecting a child, we offer paid parental leave to support you during this time. Maternity leave is 6 months paid, and paternity leave is 1 month paid. Please reach out to HR when you're ready to plan this out.
+Full-time employees get paid parental leave: 6 months for maternity, 1 month for paternity. Talk to HR when you want to plan it.
 
 ### Learning & Development
-We provide access to paid courses, certifications, and tools that help you grow in your role. If there's something specific you'd like to pursue, discuss it with your manager — we're happy to support learning that adds value to your work.
+We pay for courses, certifications, and tools that help you grow in your role. If there's something you want to pursue, discuss it with your manager.

--- a/common/compensation_benefits.md
+++ b/common/compensation_benefits.md
@@ -30,3 +30,6 @@ If you're a full-time employee and expecting a child, we offer paid parental lea
 
 ### Learning & Development
 We provide access to paid courses, certifications, and tools that help you grow in your role. If there's something specific you'd like to pursue, discuss it with your manager — we're happy to support learning that adds value to your work.
+
+Subscriptions for AI tools are not provided to associates.
+Associates are expected to make use of their student co-pilot subscriptions for AI coding tools such as GitHub Copilot, Claude, and ChatGPT as part of their work.


### PR DESCRIPTION
Added the following lines under Learning & Development: 'Subscriptions for AI tools are not provided to associates.' and 'Associates are expected to make use of their student co-pilot subscriptions for AI coding tools such as GitHub Copilot, Claude, and ChatGPT as part of their work.'